### PR TITLE
Added singleton tracking

### DIFF
--- a/src/DI.Abstractions/IServiceProviderFactory.cs
+++ b/src/DI.Abstractions/IServiceProviderFactory.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    /// <summary>
+	/// <summary>
     /// Provides an extension point for creating a container specific builder and an <see cref="IServiceProvider"/>.
     /// </summary>
     public interface IServiceProviderFactory<TContainerBuilder>

--- a/src/DI.Abstractions/IServiceProviderOptions.cs
+++ b/src/DI.Abstractions/IServiceProviderOptions.cs
@@ -1,0 +1,23 @@
+﻿namespace Microsoft.Extensions.DependencyInjection
+{
+	/// <summary>
+	/// todo
+	/// </summary>
+	public interface IServiceProviderOptions
+	{
+		/// <summary>
+		/// todo
+		/// </summary>
+		ServiceProviderMode Mode { get; set; }
+
+		/// <summary>
+		/// todo
+		/// </summary>
+		ITrackSingletonServices SingletonTracker { get; set; }
+
+		/// <summary>
+		/// <c>true</c> to perform check verifying that scoped services never gets resolved from root provider; otherwise <c>false</c>.
+		/// </summary>
+		bool ValidateScopes { get; set; }
+	}
+}

--- a/src/DI.Abstractions/IServiceProviderWithOptions.cs
+++ b/src/DI.Abstractions/IServiceProviderWithOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+	/// <summary>
+	/// todo
+	/// </summary>
+	public interface IServiceProviderWithOptions : IServiceProvider
+	{
+		/// <summary>
+		/// todo
+		/// </summary>
+		IServiceProviderOptions Options { get; }
+	}
+}

--- a/src/DI.Abstractions/ITrackSingletonServices.cs
+++ b/src/DI.Abstractions/ITrackSingletonServices.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+	/// <summary>
+	/// todo
+	/// </summary>
+	public interface ITrackSingletonServices : IDisposable
+	{
+		/// <summary>
+		/// todo
+		/// </summary>
+		/// <returns></returns>
+		object GetLock();
+
+		/// <summary>
+		/// todo
+		/// </summary>
+		/// <returns></returns>
+		IDictionary<object, object> GetResolvedSingletons();
+
+		/// <summary>
+		/// todo
+		/// </summary>
+		void TrackDisposable(object resolved);
+	}
+}

--- a/src/DI.Abstractions/ServiceProviderMode.cs
+++ b/src/DI.Abstractions/ServiceProviderMode.cs
@@ -3,11 +3,26 @@
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    internal enum ServiceProviderMode
+	/// <summary>
+	/// todo
+	/// </summary>
+    public enum ServiceProviderMode
     {
-        Dynamic,
+		/// <summary>
+		/// todo
+		/// </summary>
+	    Dynamic,
+	    /// <summary>
+	    /// todo
+	    /// </summary>
         Runtime,
+		/// <summary>
+		/// todo
+		/// </summary>
         Expressions,
+		/// <summary>
+		/// todo
+		/// </summary>
         ILEmit
-    }
+	}
 }

--- a/src/DI/ServiceCollectionContainerBuilderExtensions.cs
+++ b/src/DI/ServiceCollectionContainerBuilderExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Configures various service provider behaviors.
         /// </param>
         /// <returns>The <see cref="ServiceProvider"/>.</returns>
-        public static ServiceProvider BuildServiceProvider(this IServiceCollection services, ServiceProviderOptions options)
+        public static ServiceProvider BuildServiceProvider(this IServiceCollection services, IServiceProviderOptions options)
         {
             if (services == null)
             {

--- a/src/DI/ServiceLookup/CompiledServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/CompiledServiceProviderEngine.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     {
         public ExpressionResolverBuilder ExpressionResolverBuilder { get; }
 
-        public CompiledServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
+        public CompiledServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback, ITrackSingletonServices singletonTracker) : base(serviceDescriptors, callback, singletonTracker)
         {
             ExpressionResolverBuilder = new ExpressionResolverBuilder(RuntimeResolver, this, Root);
         }

--- a/src/DI/ServiceLookup/DynamicServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/DynamicServiceProviderEngine.cs
@@ -10,9 +10,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class DynamicServiceProviderEngine : CompiledServiceProviderEngine
     {
-        public DynamicServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
-        {
-        }
+	    public DynamicServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : this(serviceDescriptors, callback, new SingletonServiceTracker())
+	    {
+	    }
+
+		public DynamicServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback, ITrackSingletonServices singletonTracker) : base(serviceDescriptors, callback, singletonTracker)
+	    {
+	    }
 
         protected override Func<ServiceProviderEngineScope, object> RealizeService(IServiceCallSite callSite)
         {

--- a/src/DI/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     internal class ExpressionsServiceProviderEngine : ServiceProviderEngine
     {
         private readonly ExpressionResolverBuilder _expressionResolverBuilder;
-        public ExpressionsServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
+        public ExpressionsServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback, ITrackSingletonServices singletonTracker) : base(serviceDescriptors, callback, singletonTracker)
         {
             _expressionResolverBuilder = new ExpressionResolverBuilder(RuntimeResolver, this, Root);
         }

--- a/src/DI/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     internal class ILEmitServiceProviderEngine : ServiceProviderEngine
     {
         private readonly ILEmitResolverBuilder _expressionResolverBuilder;
-        public ILEmitServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
+        public ILEmitServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback, ITrackSingletonServices singletonTracker) : base(serviceDescriptors, callback, singletonTracker)
         {
             _expressionResolverBuilder = new ILEmitResolverBuilder(RuntimeResolver, this, Root);
         }

--- a/src/DI/ServiceLookup/RuntimeServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/RuntimeServiceProviderEngine.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class RuntimeServiceProviderEngine : ServiceProviderEngine
     {
-        public RuntimeServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
+        public RuntimeServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback, ITrackSingletonServices singletonTracker) : base(serviceDescriptors, callback, singletonTracker)
         {
         }
 

--- a/src/DI/ServiceLookup/ServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/ServiceProviderEngine.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private bool _disposed;
 
-        protected ServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback)
+        protected ServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback, ITrackSingletonServices singletonTracker)
         {
             _createServiceAccessor = CreateServiceAccessor;
             _callback = callback;
             Root = new ServiceProviderEngineScope(this);
-            RuntimeResolver = new CallSiteRuntimeResolver();
+            RuntimeResolver = new CallSiteRuntimeResolver(singletonTracker);
             CallSiteFactory = new CallSiteFactory(serviceDescriptors);
             CallSiteFactory.Add(typeof(IServiceProvider), new ServiceProviderCallSite());
             CallSiteFactory.Add(typeof(IServiceScopeFactory), new ServiceScopeFactoryCallSite());

--- a/src/DI/ServiceLookup/StaticServiceScope.cs
+++ b/src/DI/ServiceLookup/StaticServiceScope.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+	/// <summary>
+	/// todo
+	/// </summary>
+	public class SingletonServiceTracker : ITrackSingletonServices
+	{
+		internal static readonly object Synchronise = new object();
+
+		internal static List<object> Disposables { get; private set; } = new List<object>(); 
+
+		internal static Dictionary<object, object> StaticResolvedServices { get; } = new Dictionary<object, object>();
+
+		/// <summary>
+		/// todo
+		/// </summary>
+		/// <returns></returns>
+		public object GetLock()
+		{
+			return Synchronise;
+		}
+
+		/// <summary>
+		/// todo
+		/// </summary>
+		/// <returns></returns>
+		public IDictionary<object, object> GetResolvedSingletons()
+		{
+			return StaticResolvedServices;
+		}
+
+		/// <summary>
+		/// todo
+		/// </summary>
+		/// <param name="resolved"></param>
+		public void TrackDisposable(object resolved)
+		{
+			if (resolved is IDisposable)
+			{
+				Disposables.Add(resolved);
+			}
+		}
+
+		/// <summary>
+		/// todo
+		/// </summary>
+		public void Dispose()
+		{
+			lock (GetLock())
+			{
+				foreach (var disposable in Disposables)
+				{
+					(disposable as IDisposable)?.Dispose();
+				}
+
+				Disposables = new List<object>();
+			}
+		}
+	}
+}

--- a/src/DI/ServiceProvider.cs
+++ b/src/DI/ServiceProvider.cs
@@ -10,14 +10,21 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// The default IServiceProvider.
     /// </summary>
-    public sealed class ServiceProvider : IServiceProvider, IDisposable, IServiceProviderEngineCallback
+    public sealed class ServiceProvider : IServiceProviderWithOptions, IDisposable, IServiceProviderEngineCallback
     {
         private readonly IServiceProviderEngine _engine;
 
         private readonly CallSiteValidator _callSiteValidator;
 
-        internal ServiceProvider(IEnumerable<ServiceDescriptor> serviceDescriptors, ServiceProviderOptions options)
-        {
+		/// <summary>
+		/// todo
+		/// </summary>
+	    public IServiceProviderOptions Options { get; }
+
+	    internal ServiceProvider(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderOptions options)
+	    {
+		    Options = options;
+
             IServiceProviderEngineCallback callback = null;
             if (options.ValidateScopes)
             {
@@ -27,18 +34,18 @@ namespace Microsoft.Extensions.DependencyInjection
             switch (options.Mode)
             {
                 case ServiceProviderMode.Dynamic:
-                    _engine = new DynamicServiceProviderEngine(serviceDescriptors, callback);
+                    _engine = new DynamicServiceProviderEngine(serviceDescriptors, callback, options.SingletonTracker);
                     break;
                 case ServiceProviderMode.Runtime:
-                    _engine = new RuntimeServiceProviderEngine(serviceDescriptors, callback);
+                    _engine = new RuntimeServiceProviderEngine(serviceDescriptors, callback, options.SingletonTracker);
                     break;
 #if IL_EMIT
                 case ServiceProviderMode.ILEmit:
-                    _engine = new ILEmitServiceProviderEngine(serviceDescriptors, callback);
+                    _engine = new ILEmitServiceProviderEngine(serviceDescriptors, callback, options.SingletonTracker);
                     break;
 #endif
-                case ServiceProviderMode.Expressions:
-                    _engine = new ExpressionsServiceProviderEngine(serviceDescriptors, callback);
+				case ServiceProviderMode.Expressions:
+                    _engine = new ExpressionsServiceProviderEngine(serviceDescriptors, callback, options.SingletonTracker);
                     break;
                 default:
                     throw new NotSupportedException(nameof(options.Mode));

--- a/src/DI/ServiceProviderOptions.cs
+++ b/src/DI/ServiceProviderOptions.cs
@@ -2,14 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Extensions.DependencyInjection.ServiceLookup;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
     /// Options for configuring various behaviors of the default <see cref="IServiceProvider"/> implementation.
     /// </summary>
-    public class ServiceProviderOptions
-    {
+    public class ServiceProviderOptions : IServiceProviderOptions
+	{
         // Avoid allocating objects in the default case
         internal static readonly ServiceProviderOptions Default = new ServiceProviderOptions();
 
@@ -18,6 +19,14 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         public bool ValidateScopes { get; set; }
 
-        internal ServiceProviderMode Mode { get; set; } = ServiceProviderMode.Dynamic;
+		/// <summary>
+		/// todo
+		/// </summary>
+        public ServiceProviderMode Mode { get; set; } = ServiceProviderMode.Dynamic;
+
+		/// <summary>
+		/// todo
+		/// </summary>
+	    public ITrackSingletonServices SingletonTracker { get; set; } = new SingletonServiceTracker();
     }
 }

--- a/test/DI.Tests/ServiceProviderDynamicContainerTests.cs
+++ b/test/DI.Tests/ServiceProviderDynamicContainerTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 {
     public class ServiceProviderDynamicContainerTests : ServiceProviderContainerTests
     {
-        protected override IServiceProvider CreateServiceProvider(IServiceCollection collection) =>
+        protected override IServiceProviderWithOptions CreateServiceProvider(IServiceCollection collection) =>
             collection.BuildServiceProvider();
     }
 }

--- a/test/DI.Tests/ServiceProviderExpressionsContainerTests.cs
+++ b/test/DI.Tests/ServiceProviderExpressionsContainerTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 {
     public class ServiceProviderExpressionsContainerTests : ServiceProviderContainerTests
     {
-        protected override IServiceProvider CreateServiceProvider(IServiceCollection collection) =>
+        protected override IServiceProviderWithOptions CreateServiceProvider(IServiceCollection collection) =>
             collection.BuildServiceProvider(new ServiceProviderOptions { Mode = ServiceProviderMode.Expressions });
     }
 }

--- a/test/DI.Tests/ServiceProviderILEmitContainerTests.cs
+++ b/test/DI.Tests/ServiceProviderILEmitContainerTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 {
     public class ServiceProviderILEmitContainerTests : ServiceProviderContainerTests
     {
-        protected override IServiceProvider CreateServiceProvider(IServiceCollection collection) =>
+        protected override IServiceProviderWithOptions CreateServiceProvider(IServiceCollection collection) =>
             collection.BuildServiceProvider(new ServiceProviderOptions() { Mode = ServiceProviderMode.ILEmit});
     }
 }


### PR DESCRIPTION
This is a mock example of singleton tracking with updated tests. 

 - This allows singletons to be tracked outside of service provider/scopes. 
 - Also allows the disposal of singleton via `options`.

This could do with some improvement around how singletons are exposed via the public API.
